### PR TITLE
Update AdSense publisher ID in ads.txt

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,1 @@
-google.com, pub-2708419466378217, DIRECT, f08c47fec0942fa0
+google.com, pub-7901026683522605, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Replace the existing AdSense publisher ID in the ads.txt file to ensure accurate ad serving.